### PR TITLE
Fix adding the header

### DIFF
--- a/src/performance-log-middleware/PerformanceLogMiddleware.cs
+++ b/src/performance-log-middleware/PerformanceLogMiddleware.cs
@@ -26,6 +26,12 @@ namespace PerformanceLog
             var correlationId = context.TraceIdentifier;
 
             var stopwatch = Stopwatch.StartNew();
+            context.Response.OnStarting(() =>
+            {
+                context.Response.Headers["X-Request-Duration"] = stopwatch.Elapsed.TotalMilliseconds.ToString();
+                return Task.CompletedTask;
+            });
+
             await _next(context);
             var logEntry = new LogItem
             {
@@ -33,8 +39,6 @@ namespace PerformanceLog
                 Operation = context.Request.Path,
                 CorrelationId = correlationId
             };
-
-            context.Response.Headers.Add("X-Request-Duration", logEntry.Duration.ToString());
 
             var logger = _loggerFactory.CreateLogger("performance");
             switch (_options.LogLevel)

--- a/src/performance-log-middleware/performance-log-middleware.csproj
+++ b/src/performance-log-middleware/performance-log-middleware.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>1.4.0</Version>
+    <Version>1.4.1</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>performance-log-middleware</AssemblyName>
     <PackageId>performance-log-middleware</PackageId>


### PR DESCRIPTION
Adding the header after the middleware gives an error because the response has already started so it gives an error.